### PR TITLE
Feature: Don't include default prop values

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,18 @@ var componentToJson = function (component) {
     children = _.map(children, componentToJson);
   }
 
-  var props = _.chain(component.props)
-    .omit('children')
+  var matchingProps;
+
+  if (component.type && component.type.defaultProps) {
+    matchingProps = _.omit(component.props, function (val, key) {
+      return component.type.defaultProps[key] === component.props[key];
+    });
+  } else {
+    matchingProps = component.props;
+  }
+
+  var props = _.chain(matchingProps)
+    .omit(['children'])
     .transform(function (result, prop, key) {
       if (_.isString(prop)) {
         result[key] = prop;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-to-jsx",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "author": "Alex Lande",
   "license": "MIT",


### PR DESCRIPTION
This might be optional down the line, but it's hard to think of a case where you would explicitly want to include defaults in your example.
