### PR TITLE
Bug: Fix single node child prop bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ var componentToJson = function (component) {
   var children;
 
   if (component.props && component.props.children) {
-    children = _.clone(component.props.children);
+    children = component.props.children;
     children = _.isArray(children) ? children : [children];
+    children = _.clone(children);
     children = _.map(children, componentToJson);
   }
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ var componentToJson = function (component) {
   if (component.props && component.props.children) {
     children = component.props.children;
     children = _.isArray(children) ? children : [children];
-    children = _.clone(children);
     children = _.map(children, componentToJson);
   }
 


### PR DESCRIPTION
This fixes a bug where rendered components with only one child would count as the last chain, even if that child had children. E.g.

```
<Form>
  <div>
    <Button />
  </div>
</Form>
```

This would resolve to `<Form><div /></Form>` and never get to the button because `_.clone` strips away `props`.  React has `props` set to _not_ be an enumerable property, which is how `_.clone` decides which keys to copy.  

The reason this works for arrays of children is that it's a shallow clone.

/cc @alexlande 
