### PR TITLE
Feature: Add undefined check and exclusion options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,21 @@ console.log(jsxString);
 
 `reactToJsx` takes an optional `options` object: `reactToJsx(reactElement, options)`.
 
-#### Indent
+#### `indent`
 
 Type: `String` Default: `'\t'` (Tab)
 
 Sets the indent string for returned JSX. Should probably match your preferred
 code style. Two spaces? Four? Three? The choice is yours, friend.
+
+#### `includeNull`
+
+Type: 'Boolean' Default: `true`
+
+Determines whether to include props with a value of `null` in the returned JSX.
+
+#### `exclude`
+
+Type: `Array` Default: `[]`
+
+Array of props to exclude from the returned JSX. Hide those weird props, they shouldn't be in your docs anyway.


### PR DESCRIPTION
This started as a bug and grew to some features!

`react-to-jsx` no longer returns `undefined` props if you somehow managed to get one of your props `undefined`.

Also added options to exclude props with a value of `null` and an option to exclude props from the returned JSX.

Closes #5.
Closes #4. 
