### PR TITLE
allow omitting boolean attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ Determines whether to include props with a value of `null` in the returned JSX.
 Type: `Array` Default: `[]`
 
 Array of props to exclude from the returned JSX. Hide those weird props, they shouldn't be in your docs anyway.
+
+#### `omitBools`
+
+Type: `Boolean` Default: `false`
+
+If enabled, boolean attributes that are set to true (`primary={true}`) will use the short syntax (`primary`)
+See https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes

--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ var reactToJsx = function (component, options) {
   var defaults = {
     indent: '\t',
     includeNull: true,
-    exclude: []
+    exclude: [],
+    omitBools: false
   };
 
   var config = _.extend({}, defaults, options);
@@ -102,6 +103,11 @@ var reactToJsx = function (component, options) {
 
   componentArray = _.map(componentArray, function (line) {
     var attributeMatcher = /\s+(?=\S*=)/g;
+
+    if (config.omitBools) {
+      var attributeShortener = /\s(\S*)=\{true\}/g;
+      line = line.replace(attributeShortener, ' $1');
+    }
 
     if ((line.match(attributeMatcher) || []).length < 2) {
       return line;


### PR DESCRIPTION
according to https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes it is ok to omit the value of boolean attributes if the value is true.

This PR allows (via configuration) that

```
<Button primary={true}>A Button</Button>
```

becomes

```
<Button primary>A Button</Button>
```
